### PR TITLE
Cargo test on docker

### DIFF
--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -12,7 +12,7 @@ services:
       - "5433:5432"
   krust-post:
     build:
-      context: .
+      context: ./krust-post
     depends_on:
       - postgres
       - nats

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -1,0 +1,42 @@
+version: "3.5"
+services:
+  postgres:
+    image: postgres:14.5
+    volumes:
+      - ./pg-init-scripts:/docker-entrypoint-initdb.d
+    environment:
+      - POSTGRES_MULTIPLE_DATABASES=k_rust_post
+      - POSTGRES_USER=k-rust
+      - POSTGRES_PASSWORD=abcabc123
+    ports:
+      - "5433:5432"
+  krust-post:
+    build:
+      context: .
+    depends_on:
+      - postgres
+      - nats
+    environment:
+      - RUST_BACKTRACE=1
+    command: "cargo test"
+  nats:
+    image: nats
+    ports:
+      - "8222:8222"
+      - "4222:4222"
+
+    command: "--http_port 8222 -js"
+    networks: ["nats"]
+  # nats-1:
+  #   image: nats
+  #   command: "--cluster_name NATS --cluster nats://0.0.0.0:6222 --routes=nats://ruser:T0pS3cr3t@nats:6222"
+  #   networks: ["nats"]
+  #   depends_on: ["nats"]
+  # nats-2:
+  #   image: nats
+  #   command: "--cluster_name NATS --cluster nats://0.0.0.0:6222 --routes=nats://ruser:T0pS3cr3t@nats:6222"
+  #   networks: ["nats"]
+  #   depends_on: ["nats"]
+networks:
+  nats:
+    name: nats

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -24,19 +24,8 @@ services:
     ports:
       - "8222:8222"
       - "4222:4222"
-
     command: "--http_port 8222 -js"
     networks: ["nats"]
-  # nats-1:
-  #   image: nats
-  #   command: "--cluster_name NATS --cluster nats://0.0.0.0:6222 --routes=nats://ruser:T0pS3cr3t@nats:6222"
-  #   networks: ["nats"]
-  #   depends_on: ["nats"]
-  # nats-2:
-  #   image: nats
-  #   command: "--cluster_name NATS --cluster nats://0.0.0.0:6222 --routes=nats://ruser:T0pS3cr3t@nats:6222"
-  #   networks: ["nats"]
-  #   depends_on: ["nats"]
 networks:
   nats:
     name: nats


### PR DESCRIPTION
## Description

- CI on Docker 코드를 구성합니다.
- 테스트 환경에 대한 docker-compose.test.yaml을 구성합니다.

## TODOs

- krust-post
  - 현재 `docker compose -f docker-compose.test.yaml up --build`로 매뉴얼하게 테스트 결과를 확인하고 있습니다.
     추후 Github Actions등 CI 정의에서는 `docker compose -f docker-compose.test.yaml run ~~` 커맨드등으로 테스트에 대한 Entrypoint를 매뉴얼하게 호출해야 합니다.
- krust-web
  - 현재 krust-web/dev/cargo-test-on-docker의 경우 host.docker.internal로 주소를 고정하고 있어 로컬 테스트에 대한 .env 분리가 필요합니다.